### PR TITLE
フォームから店舗名を送信して保存する

### DIFF
--- a/app/controllers/admin/cafes_controller.rb
+++ b/app/controllers/admin/cafes_controller.rb
@@ -1,5 +1,6 @@
 class Admin::CafesController < Admin::BaseController
   def new
+    @cafe = Cafe.new
   end
 
   def create
@@ -8,6 +9,7 @@ class Admin::CafesController < Admin::BaseController
     uri = URI.parse("https://maps.googleapis.com/maps/api/geocode/json?#{params}&key=#{ENV["MAP_API_KEY"]}")
     response = Net::HTTP.get_response(uri)
     @result = JSON.parse(response.body)
+    binding.pry
     @cafe = Cafe.new(
       name: cafe_params["name"],
       address: cafe_params["address"],
@@ -26,6 +28,6 @@ class Admin::CafesController < Admin::BaseController
   private
   
     def cafe_params
-      params.require(:cafe).permit(:name, :address, :latitude, :longitude)
+      params.permit(:name, :address, :latitude, :longitude)
     end
 end

--- a/app/controllers/admin/cafes_controller.rb
+++ b/app/controllers/admin/cafes_controller.rb
@@ -7,15 +7,12 @@ class Admin::CafesController < Admin::BaseController
     uri = URI.parse("https://maps.googleapis.com/maps/api/geocode/json?#{params}&key=#{ENV["MAP_API_KEY"]}")
     response = Net::HTTP.get_response(uri)
     @result = JSON.parse(response.body)
-    # binding.pry
     @cafe = Cafe.new(
       name: cafe_params["name"],
       address: cafe_params["address"],
       latitude: @result["results"][0]["geometry"]["location"]["lat"],
       longitude: @result["results"][0]["geometry"]["location"]["lng"]
     )
-    # binding.pry
-    #保存
     if @cafe.save
       puts "保存に成功"
       redirect_to cafes_path

--- a/app/controllers/admin/cafes_controller.rb
+++ b/app/controllers/admin/cafes_controller.rb
@@ -1,9 +1,10 @@
 class Admin::CafesController < Admin::BaseController
   def new
   end
+
   def create
-    address = params[:cafe]
-    params = URI.encode_www_form({address: address})
+    shop = params[:cafe]
+    params = URI.encode_www_form({address: shop})
     uri = URI.parse("https://maps.googleapis.com/maps/api/geocode/json?#{params}&key=#{ENV["MAP_API_KEY"]}")
     response = Net::HTTP.get_response(uri)
     @result = JSON.parse(response.body)

--- a/app/controllers/admin/cafes_controller.rb
+++ b/app/controllers/admin/cafes_controller.rb
@@ -9,7 +9,6 @@ class Admin::CafesController < Admin::BaseController
     uri = URI.parse("https://maps.googleapis.com/maps/api/geocode/json?#{params}&key=#{ENV["MAP_API_KEY"]}")
     response = Net::HTTP.get_response(uri)
     @result = JSON.parse(response.body)
-    binding.pry
     @cafe = Cafe.new(
       name: cafe_params["name"],
       address: cafe_params["address"],

--- a/app/controllers/admin/cafes_controller.rb
+++ b/app/controllers/admin/cafes_controller.rb
@@ -7,11 +7,14 @@ class Admin::CafesController < Admin::BaseController
     uri = URI.parse("https://maps.googleapis.com/maps/api/geocode/json?#{params}&key=#{ENV["MAP_API_KEY"]}")
     response = Net::HTTP.get_response(uri)
     @result = JSON.parse(response.body)
+    # binding.pry
     @cafe = Cafe.new(
+      name: cafe_params["name"],
       address: cafe_params["address"],
       latitude: @result["results"][0]["geometry"]["location"]["lat"],
       longitude: @result["results"][0]["geometry"]["location"]["lng"]
     )
+    # binding.pry
     #保存
     if @cafe.save
       puts "保存に成功"
@@ -25,6 +28,6 @@ class Admin::CafesController < Admin::BaseController
   private
   
     def cafe_params
-      params.require(:cafe).permit(:address, :latitude, :longitude)
+      params.require(:cafe).permit(:name, :address, :latitude, :longitude)
     end
 end

--- a/app/models/cafe.rb
+++ b/app/models/cafe.rb
@@ -1,3 +1,4 @@
 class Cafe < ApplicationRecord
   validates:address, presence: true, length: {maximum: 50}
+  validates:name, presence: true, length: {maximum: 40}
 end

--- a/app/views/admin/cafes/new.html.slim
+++ b/app/views/admin/cafes/new.html.slim
@@ -1,4 +1,4 @@
-= form_with model:Cafe, url: admin_cafes_path, local: true do |f|
+= form_with model:@cafe, url: admin_cafes_path, local: true do |f|
   = f.text_field :name, placeholder: "LUCENT COFFEE"
   = f.text_field :address, placeholder: "東京都港区芝公園4-2−8"
   = f.submit "登録する"

--- a/app/views/admin/cafes/new.html.slim
+++ b/app/views/admin/cafes/new.html.slim
@@ -1,5 +1,5 @@
 = form_with model:Cafe, url: admin_cafes_path, local: true do |f|
-  = f.text_field :name, placeholder: "店舗名"
+  = f.text_field :name, placeholder: "LUCENT COFFEE"
   = f.text_field :address, placeholder: "東京都港区芝公園4-2−8"
   = f.submit "登録する"
 

--- a/app/views/admin/cafes/new.html.slim
+++ b/app/views/admin/cafes/new.html.slim
@@ -1,5 +1,5 @@
 = form_with model:@cafe, url: admin_cafes_path, local: true do |f|
-  = f.text_field :name, placeholder: "LUCENT COFFEE"
+  = f.text_field :name, placeholder: "XX COFFEE RASTER"
   = f.text_field :address, placeholder: "東京都港区芝公園4-2−8"
   = f.submit "登録する"
 

--- a/app/views/admin/cafes/new.html.slim
+++ b/app/views/admin/cafes/new.html.slim
@@ -1,4 +1,5 @@
 = form_with model:Cafe, url: admin_cafes_path, local: true do |f|
+  = f.text_field :name, placeholder: "店舗名"
   = f.text_field :address, placeholder: "東京都港区芝公園4-2−8"
   = f.submit "登録する"
 

--- a/spec/models/cafe_model_spec.rb
+++ b/spec/models/cafe_model_spec.rb
@@ -2,7 +2,10 @@ require "rails_helper"
 
 RSpec.describe Cafe, type: :model do
   it "is invalid without an address" do
-    hoge = Cafe.new(address: "")
+    hoge = Cafe.new(
+      name: "",
+      address: ""
+    )
     hoge.valid?
     expect(hoge.errors[:address]).to include("can't be blank")
   end

--- a/spec/models/cafe_model_spec.rb
+++ b/spec/models/cafe_model_spec.rb
@@ -1,12 +1,18 @@
 require "rails_helper"
 
 RSpec.describe Cafe, type: :model do
-  it "is invalid without an address" do
+  it "nameとaddressが空では保存できない" do
     hoge = Cafe.new(
       name: "",
       address: ""
     )
-    hoge.valid?
-    expect(hoge.errors[:address]).to include("can't be blank")
+    expect(hoge.save).to be_falsey #nameとaddressが空なのでfalseを期待する
+  end
+  it "nameとaddressを埋めると保存できる" do
+    foo = Cafe.new(
+      name: "Cafe1",
+      address: "東京都千代田区1-1"
+    )
+    expect(foo.save).to be_truthy
   end
 end

--- a/spec/models/cafe_model_spec.rb
+++ b/spec/models/cafe_model_spec.rb
@@ -1,18 +1,19 @@
 require "rails_helper"
 
 RSpec.describe Cafe, type: :model do
-  it "nameとaddressが空では保存できない" do
-    hoge = Cafe.new(
-      name: "",
-      address: ""
-    )
-    expect(hoge.save).to be_falsey #nameとaddressが空なのでfalseを期待する
-  end
   it "nameとaddressを埋めると保存できる" do
     foo = Cafe.new(
       name: "Cafe1",
       address: "東京都千代田区1-1"
     )
     expect(foo.save).to be_truthy
+  end
+
+  it "nameとaddressが空では保存できない" do
+    hoge = Cafe.new(
+      name: "",
+      address: ""
+    )
+    expect(hoge.save).to be_falsey
   end
 end

--- a/spec/requests/address_spec.rb
+++ b/spec/requests/address_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Address", type: :request do
   describe "POST /admin/cafes/new"
     it "住所をDBに保存する" do
-      post cafes_path, params: {cafe: {address: "address", latitude: "latitude", longitude: "longitude" }}
+      post admin_cafes_path, params: {cafe: {name: "cafe", address: "address", latitude: "latitude", longitude: "longitude" }}
       expect(response).to redirect_to cafes_path
     end
 end


### PR DESCRIPTION
# 目的
フォームから店舗名を送信して保存できるようにする

# タスク
- [x] viewに名前を追加
- [x] パラメータとして名前を渡す
- [x] 店舗名、住所、緯度経度を一緒に保存する