### PR TITLE
[question]存在しない住所のときに「保存できません」とメッセージを表示する

### DIFF
--- a/app/controllers/admin/cafes_controller.rb
+++ b/app/controllers/admin/cafes_controller.rb
@@ -6,7 +6,6 @@ class Admin::CafesController < Admin::BaseController
   def create
     @result = MapQuery.new(params[:cafe]).result
     @status = MapQuery.new(params[:cafe]).status
-    binding.pry
 
     @cafe = Cafe.new(
       name: cafe_params["name"],

--- a/app/controllers/admin/cafes_controller.rb
+++ b/app/controllers/admin/cafes_controller.rb
@@ -5,6 +5,8 @@ class Admin::CafesController < Admin::BaseController
 
   def create
     @result = MapQuery.new(params[:cafe]).result
+    @status = MapQuery.new(params[:cafe]).status
+    binding.pry
 
     @cafe = Cafe.new(
       name: cafe_params["name"],

--- a/app/controllers/admin/cafes_controller.rb
+++ b/app/controllers/admin/cafes_controller.rb
@@ -18,6 +18,9 @@ class Admin::CafesController < Admin::BaseController
     if @cafe.save
       flash[:notice] = "保存しました"
       redirect_to cafes_path
+    elsif @status != "OK"
+      flash.now[:danger] = "保存に失敗しました"
+      render action: :new
     else
       flash.now[:danger] = "保存に失敗しました"
       render action: :new

--- a/app/models/cafe.rb
+++ b/app/models/cafe.rb
@@ -1,5 +1,4 @@
 class Cafe < ApplicationRecord
-  validates:address, presence: true, length: {maximum: 50}, format: {
-    with: /...??[都道府県]/}
+  validates:address, presence: true, length: {maximum: 50}
   validates:name, presence: true, length: {maximum: 40}
 end

--- a/app/models/map_query.rb
+++ b/app/models/map_query.rb
@@ -6,7 +6,13 @@ class MapQuery
 
   def uri
     address = URI.encode_www_form({address: @cafe_param})
-    URI.parse("https://maps.googleapis.com/maps/api/geocode/json?#{address}&key=#{ENV["MAP_API_KEY"]}")
+    URI.parse("https://maps.googleapis.com/maps/api/geocode/json?address=#{address}&key=#{ENV["MAP_API_KEY"]}")
+  end
+
+  def status
+    api_response = Net::HTTP.get_response(uri)
+    response_body = JSON.parse(api_response.body)
+    response_body["status"]
   end
 
   def result


### PR DESCRIPTION
# 実装したいこと/ゴール

Geocoding APIのレスポンスが`"OK"`以外のとき、保存できない旨のメッセージを表示する

# 困っていること

アプリからAPIを叩いた時と、ブラウザでAPIを直接叩いた時のhttp statusが異なっている。
そのため、フォームに存在しない住所を入力しても保存されてしまう。

## 例えば、「東京稚内」と存在しない住所を入れた場合

### アプリのフォームに入力してpryでパラメータと`STATUS`を確認 => OKになっている

![スクリーンショット 2021-05-07 23 39 05](https://user-images.githubusercontent.com/45246171/117466229-713ced80-af8d-11eb-8335-d80d307167e5.png)

### chromeで直接APIを叩いた時 => ZERO_RESULTになっている

![スクリーンショット 2021-05-07 23 39 55](https://user-images.githubusercontent.com/45246171/117466341-8e71bc00-af8d-11eb-91c4-1f3153215d24.png)


「東京稚内」と入れた場合は、ZERO_RESULTなので本来は保存できないが、内部ではOKになっているので保存ができてしまう